### PR TITLE
enhance(setup): changed readme and added example-env and bashfile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+MONGODB_URI=your_mongodb_uri_here
+MONGO_DB_NAME_TEST=your_test_db_name_here
+GEMINI_API=your_gemini_api_key_here
+JWT_SECRET_KEY=your_jwt_secret_key_here
+ACCESS_TOKEN_EXPIRE_MINUTES=your_access_token_expiry_minutes_here

--- a/README.md
+++ b/README.md
@@ -22,11 +22,21 @@ cd BACK_Kaizen
 
 ## 2. Crear y activar entorno virtual
 
+Recomendado: puedes agregar dev.sh como un bash file
 ```bash
-python3 -m venv venv
-source venv/bin/activate    # (Linux/Mac)
+chmod +x dev.sh
+```
+Y luego correrlo con
+```bash
+./dev.sh
+```
+Revisará que tengas .env, .venv, los requerimientos y correrá todo junto.
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate    # (Linux/Mac)
 # o en Windows:
-# venv\\Scripts\\activate
+# .venv\\Scripts\\activate
 ```
 
 ## 3. Instalar dependencias
@@ -38,6 +48,9 @@ pip install -r requirements.txt
 ## 4. Configurar variables de entorno
 
 1. Crea un archivo llamado `.env` en la raíz del proyecto.
+```bash
+cp .env.example .env
+```
 2. Define al menos estas variables (ejemplo):
 
 ```
@@ -55,6 +68,13 @@ ACCESS_TOKEN_EXPIRE_MINUTES=60
 ```bash
 cd src
 uvicorn app.main:app --reload
+```
+
+o puedes usar
+
+```bash
+cd src
+uvicorn main:app --reload
 ```
 
 - La opción `--reload` permite recargar automáticamente el servidor cuando cambias código.
@@ -93,3 +113,8 @@ Puedes usar curl, Postman o Insomnia para probar:
 
 Presiona `Ctrl+C` en la terminal donde corre `uvicorn`.
 
+Luego, para salir del entorno virtual escribe
+
+```bash
+deactivate
+```

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+echo "Setting virtual environment."
+if [ -d ".venv" ]; then
+    echo "Virtual environment already exists."
+    source .venv/bin/activate
+else
+    echo "Creating virtual environment..."
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install -r requirements.txt
+fi
+
+echo "Development environment set up."
+if [ -f .env ]; then
+    echo ".env file already exists."
+    echo "Starting the application..."
+    cd src/
+    exec uvicorn main:app --reload
+else
+    cp .env.example .env
+    echo ".env file created from example."
+fi


### PR DESCRIPTION
This pull request introduces enhancements to the development setup and documentation for the project. Key changes include the addition of a `dev.sh` script for simplifying environment setup, updates to the `.env.example` file for environment variable configuration, and improvements to the `README.md` to provide clearer instructions for developers.

### Development Environment Setup

* **Added `dev.sh` script for automated setup**: The script handles virtual environment creation, dependency installation, `.env` file setup, and application startup. It simplifies the onboarding process for developers. (`dev.sh`, [dev.shR1-R22](diffhunk://#diff-e467af283c7153901d6c6e177357377485e8f52e407d7eb9eeb172721520824aR1-R22))

### Environment Variable Configuration

* **Updated `.env.example` file**: Added placeholders for essential environment variables such as `MONGODB_URI`, `JWT_SECRET_KEY`, and others to guide developers in configuring their local environment. (`.env.example`, [.env.exampleR1-R5](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR1-R5))

### Documentation Updates

* **Improved virtual environment setup instructions**: Added steps to use the `dev.sh` script for setting up the development environment, reducing manual steps. (`README.md`, [README.mdR25-R39](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R25-R39))
* **Added `.env` file creation command**: Included a command to copy `.env.example` to `.env` for easier configuration. (`README.md`, [README.mdR51-R53](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R51-R53))
* **Clarified application startup options**: Provided an alternative command for running the application from the `src` directory. (`README.md`, [README.mdR73-R79](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73-R79))
* **Documented virtual environment deactivation**: Added instructions on how to exit the virtual environment after development. (`README.md`, [README.mdR116-R120](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R116-R120))